### PR TITLE
percent to 12 decimal places

### DIFF
--- a/vBridge/kpi_format.py
+++ b/vBridge/kpi_format.py
@@ -25,7 +25,7 @@
         "change_type": "pts_change",
         "formats": {
             "period_values": {"type": "percentage"},
-            "pts_change": {"type": "percentage_precise"},
+            "pts_change": {"type": "percentage"},
             "percent_change": {"type": "percentage"},
             "contribution": {"type": "bps"}
         }
@@ -46,7 +46,7 @@
         "change_type": "pts_change",
         "formats": {
             "period_values": {"type": "percentage"},
-            "pts_change": {"type": "percentage_precise"},
+            "pts_change": {"type": "percentage"},
             "percent_change": {"type": "percentage"},
             "contribution": {"type": "bps"}
         }
@@ -76,8 +76,8 @@
         "calc_from": "Total Click Through Rate",
         "change_type": "pts_change",
         "formats": {
-            "period_values": {"type": "percentage_precise"},
-            "pts_change": {"type": "percentage_precise"},
+            "period_values": {"type": "percentage"},
+            "pts_change": {"type": "percentage"},
             "percent_change": {"type": "percentage"},
             "contribution": {"type": "bps"}
         }

--- a/vBridge/scripts/config_manager.py
+++ b/vBridge/scripts/config_manager.py
@@ -76,11 +76,8 @@ class ConfigManager:
             else:
                 return f"-${abs(value):,.{decimals}f}"
         elif format_type == 'percentage':
-            # Standard percentage with 1 decimal place (e.g., "13.1%")
-            return f"{value * 100:.1f}%"
-        elif format_type == 'percentage_precise':
-            # Precise percentage with 2 decimal places (e.g., "12.45%")
-            return f"{value * 100:.2f}%"
+            # Percentage as decimal format with 12 decimal places (e.g., 0.131000000000)
+            return f"{value:.12f}"
         elif format_type == 'bps':
             decimals = format_spec.get('decimals', 0)
             # Don't append BPS to the value, it will be in the column header


### PR DESCRIPTION
Update KPI percentage formatting to 12 decimal places
Summary:
Standardized all KPI percentage values to display as decimal format with 12 decimal places, removing the distinction between standard and precise percentage formatting.
Changes:
Updated kpi_format.py: Replaced all percentage_precise references with percentage for consistent formatting
Updated config_manager.py: Consolidated percentage formatting logic to use 12 decimal places (.12f) for all percentage values
Removed separate handling for percentage_precise format type
Impact:
All percentage change fields in KPI reports now display with consistent 12-decimal precision
Simplified formatting configuration by eliminating dual percentage format types
Output format changed from percentage notation (e.g., "19.1%") to decimal notation (e.g., "0.191000000000")